### PR TITLE
Enable moving launcher during editing and add clock-in reminder bar

### DIFF
--- a/ProjectLauncher/ProjectLauncher/Form1.cs
+++ b/ProjectLauncher/ProjectLauncher/Form1.cs
@@ -114,7 +114,8 @@ namespace ProjectLauncher
             }
 
             var viewForm = new ViewProjectsForm(selectedProject);
-            viewForm.ShowDialog();
+            // Open as modeless so the main window can still be moved while editing
+            viewForm.Show();
         }
 
         private void ButtonDeleteProject_Click(object sender, EventArgs e)

--- a/TimeLauncher/TimeLauncher/ClockedInOverlay.cs
+++ b/TimeLauncher/TimeLauncher/ClockedInOverlay.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace TimeLauncher
+{
+    public class ClockedInOverlay : Form
+    {
+        private Label lblMessage;
+
+        public ClockedInOverlay(string projectName)
+        {
+            this.FormBorderStyle = FormBorderStyle.FixedToolWindow;
+            this.StartPosition = FormStartPosition.Manual;
+            this.TopMost = true;
+            this.ShowInTaskbar = false;
+            this.Size = new Size(200, 40);
+
+            var screen = Screen.PrimaryScreen.WorkingArea;
+            this.Location = new Point(screen.Right - this.Width - 10, screen.Bottom - this.Height - 10);
+
+            lblMessage = new Label
+            {
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleCenter
+            };
+            this.Controls.Add(lblMessage);
+
+            UpdateProject(projectName);
+        }
+
+        public void UpdateProject(string projectName)
+        {
+            lblMessage.Text = $"Clocked in: {projectName}";
+        }
+    }
+}

--- a/TimeLauncher/TimeLauncher/TimeLauncher.csproj
+++ b/TimeLauncher/TimeLauncher/TimeLauncher.csproj
@@ -69,6 +69,9 @@
     <Compile Include="ReminderForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="ClockedInOverlay.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Services\LogService.cs" />
     <Compile Include="Services\SessionManager.cs" />
     <Compile Include="TaskEntryDialog.cs">

--- a/TimeLauncher/TimeLauncher/TimeLauncherForm.cs
+++ b/TimeLauncher/TimeLauncher/TimeLauncherForm.cs
@@ -30,6 +30,7 @@ namespace TimeLauncher
         private TaskItem currentTask;
         private DateTime? clockInTime;
         private Label lblTrackingInfo; // 🆕
+        private ClockedInOverlay clockedInOverlay; // 🆕 always-on-top reminder
 
 
         public TimeLauncherForm()
@@ -281,6 +282,12 @@ namespace TimeLauncher
             });
             UpdateTrackingLabel(); // 🆕
 
+            if (clockedInOverlay == null || clockedInOverlay.IsDisposed)
+                clockedInOverlay = new ClockedInOverlay(currentProject.ProjectName);
+            else
+                clockedInOverlay.UpdateProject(currentProject.ProjectName);
+            clockedInOverlay.Show();
+
         }
 
         private void BtnTimeOut_Click(object sender, EventArgs e)
@@ -330,6 +337,9 @@ namespace TimeLauncher
             lblTimer.Text = "00:00:00";
             clockInTime = null;
             SessionManager.ClearSession();
+
+            clockedInOverlay?.Close();
+            clockedInOverlay = null;
 
             if (manual)
                 MessageBox.Show($"Clocked out. Duration: {log.Duration.TotalMinutes:F1} minutes");
@@ -427,6 +437,9 @@ namespace TimeLauncher
             timerElapsed.Start();
             hourlyPromptTimer.Start();
             UpdateTrackingLabel(); // 🆕
+
+            clockedInOverlay = new ClockedInOverlay(currentProject.ProjectName);
+            clockedInOverlay.Show();
 
         }
         private void UpdateTrackingLabel() // 🆕


### PR DESCRIPTION
## Summary
- Allow editing project files without blocking the main launcher window
- Add always-on-top reminder bar that shows when clocked in to a project

## Testing
- `dotnet build ProjectLauncher/ProjectLauncher.sln` *(fails: command not found)*
- `msbuild ProjectLauncher/ProjectLauncher.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c19a10cd348333a92865884258a260