### PR TITLE
Allow clock in button to switch active project

### DIFF
--- a/TimeLauncher/TimeLauncher/TimeLauncherForm.cs
+++ b/TimeLauncher/TimeLauncher/TimeLauncherForm.cs
@@ -607,6 +607,12 @@ namespace TimeLauncher
                    project.ProjectName.Equals(OverheadProjectName, StringComparison.OrdinalIgnoreCase);
         }
 
+        private bool IsSameProject(TimeProject first, TimeProject second)
+        {
+            return first != null && second != null &&
+                   string.Equals(first.ProjectName, second.ProjectName, StringComparison.OrdinalIgnoreCase);
+        }
+
         private void PersistSession()
         {
             SessionManager.SaveSession(new SessionManager.SessionData
@@ -634,11 +640,21 @@ namespace TimeLauncher
                 return;
             }
 
-            if (clockInTime != null)
+            var trackingProject = GetTrackingProject();
+            bool isAlreadyClockedIntoSelectedProject = clockInTime != null &&
+                                                      IsSameProject(trackingProject, currentProject);
+            bool switchingProjects = clockInTime != null && !isAlreadyClockedIntoSelectedProject;
+
+            if (isAlreadyClockedIntoSelectedProject)
             {
                 if (showAlreadyClockedInMessage)
                     MessageBox.Show("Already clocked in.");
                 return;
+            }
+
+            if (switchingProjects)
+            {
+                ClockOut(manual: false);
             }
 
             clockInTime = DateTime.Now;


### PR DESCRIPTION
## Summary
- add project comparison helper to detect when the user is clocked into the selected project
- switch active clock-in to the newly selected project instead of showing an error when already clocked into a different project

## Testing
- Not run (dotnet CLI not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941923571f48333a65ca6d03dfdadab)